### PR TITLE
chore: relax Node engine requirement to >=22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "git+https://github.com/vansergen/rpc-request.git"
   },
   "engines": {
-    "node": ">=22.12.0",
-    "npm": ">=10.9.0"
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This pull request updates the `engines` field in `package.json` so that the package can accept any Node 22.x version (starting from 22.0.0) instead of requiring `>=22.12.0`. An issue arose when using Node 22.6.0, which was flagged as unsupported due to the current `engines` setting:

```
npm WARN EBADENGINE Unsupported engine {
  package: 'rpc-request@8.0.0',
  required: { node: '>=22.12.0', npm: '>=10.9.0' },
  current: { node: 'v22.6.0', npm: '10.9.2' }
}
```

The package does not support Node versions less than 22.0, which is intentional, but it should allow any version in the 22.x range (starting at 22.0.0). The new `engines` setting (Node >=22.0.0 and npm >=10.0.0) fixes the EBADENGINE warnings.

**Changes**:
- Update `node` version requirement from `>=22.12.0` to `>=22.0.0`
- Update `npm` version requirement to `>=10.0.0`

```jsonc
// package.json (excerpt)
{
  "engines": {
    "node": ">=22.0.0",
    "npm": ">=10.0.0"
  },
  // ... rest of package.json
}
```